### PR TITLE
Added command to verify the pull secret

### DIFF
--- a/articles/openshift/howto-add-update-pull-secret.md
+++ b/articles/openshift/howto-add-update-pull-secret.md
@@ -131,10 +131,17 @@ This section walks through updating that pull secret with additional values from
 Run the following command to update your pull secret.
 
 > [!NOTE]
-> Running this command will cause your cluster nodes to restart one by one as they're updated.
+> In ARO 4.9 or older, running this command will cause your cluster nodes to restart one by one as they're updated.
+> In ARO 4.10 version or later a restart will not be triggered.
 
 ```console
 oc set data secret/pull-secret -n openshift-config --from-file=.dockerconfigjson=./pull-secret.json
+```
+
+### Verify that pull secret is in place
+
+```
+oc exec $(oc get pod -n openshift-apiserver -o jsonpath="{.items[0].metadata.name}") -- cat /var/lib/kubelet/config.json
 ```
 
 After the secret is set, you're ready to enable Red Hat Certified Operators.


### PR DESCRIPTION
Adding the pull secret does not restart the nodes in clusters that are 4.10 or later https://docs.openshift.com/container-platform/4.10/release_notes/ocp-4-10-release-notes.html Added also a command to verify the pull secret directly in the node